### PR TITLE
Flesh out Biolink-driven semantic operations

### DIFF
--- a/icees_api/features/knowledgegraph.py
+++ b/icees_api/features/knowledgegraph.py
@@ -536,6 +536,19 @@ def one_hop(conn, query, verbose=False):
         if len(edges_dict) != 1:
             raise NotImplementedError("Number of edges in query graph must be 1")
 
+        if "biolink:correlated_with" not in next(iter(edges_dict.values()))["predicates"]:
+            return {
+                "reasoner_id": "ICEES",
+                "tool_version": TOOL_VERSION,
+                "datetime": datetime.datetime.now().strftime("%Y-%m-%D %H:%M:%S"),
+                "n_results": 0,
+                "message_code": "OK",
+                "code_description": "",
+                "query_graph": query_graph,
+                "knowledge_graph": {"nodes": {}, "edges": {}},
+                "results": [],
+            }
+
         edge_id, edge = next(iter(edges_dict.items()))
 
         source_id = edge["subject"]

--- a/icees_api/features/knowledgegraph.py
+++ b/icees_api/features/knowledgegraph.py
@@ -16,6 +16,7 @@ from .mappings import mappings
 from .data_sources import data_sources
 from .sql import get_ids_by_feature, select_associations_to_all_features, select_feature_matrix, get_feature_levels
 from .identifiers import get_identifiers, get_features_by_identifier
+from .qgraph_utils import normalize_qgraph
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -526,6 +527,7 @@ def one_hop(conn, query, verbose=False):
         maximum_p_value = query_options.get("maximum_p_value", MAX_P_VAL_DEFAULT)
         filter_regex = query_options.get("regex", ".*")
         query_graph = message["query_graph"]
+        normalize_qgraph(query_graph)
 
         nodes_dict = query_graph["nodes"]
         edges_dict = query_graph["edges"]
@@ -558,12 +560,6 @@ def one_hop(conn, query, verbose=False):
         target_id = edge["object"]
         target_node_types = nodes_dict[target_id]["categories"]
 
-        supported_types = list({
-            subtype
-            for target_node_type in target_node_types
-            for subtype in closure_subtype(target_node_type)
-        })
-
         def p_values(feature_list):
             return [feature["p_value"] for feature in feature_list]
 
@@ -584,7 +580,7 @@ def one_hop(conn, query, verbose=False):
                     cohort_id,
                     feature,
                     maximum_p_value,
-                    feature_set=lambda x: type_is_supported(x, supported_types),
+                    feature_set=lambda x: type_is_supported(x, target_node_types),
                 )
                 for feature in ataf:
                     feature_name = feature["feature_b"]["feature_name"]

--- a/icees_api/features/qgraph_utils.py
+++ b/icees_api/features/qgraph_utils.py
@@ -37,6 +37,6 @@ def normalize_qgraph(qgraph):
     for edge in qgraph["edges"].values():
         edge["predicates"] = [
             descendant
-            for predicate in node.get("predicates", None) or ["biolink:related_to"]
+            for predicate in edge.get("predicates", None) or ["biolink:related_to"]
             for descendant in get_subpredicates(predicate)
         ]

--- a/icees_api/features/qgraph_utils.py
+++ b/icees_api/features/qgraph_utils.py
@@ -1,0 +1,42 @@
+"""Query graph utilities."""
+import re
+
+from bmt import Toolkit
+
+BMT = Toolkit()
+
+
+def get_subcategories(category):
+    """Get sub-categories, according to the Biolink model."""
+    return BMT.get_descendants(category, formatted=True, reflexive=True)
+
+
+def camelcase_to_snakecase(string):
+    """Convert CamelCase to snake_case."""
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", string).lower()
+
+
+def get_subpredicates(predicate):
+    """Get sub-predicates, according to the Biolink model."""
+    curies = BMT.get_descendants(predicate, formatted=True, reflexive=True)
+    return [
+        "biolink:" + camelcase_to_snakecase(curie[8:])
+        for curie in curies
+    ]
+
+
+def normalize_qgraph(qgraph):
+    """Normalize query graph."""
+    for node in qgraph["nodes"].values():
+        node["categories"] = [
+            descendant
+            for category in node.get("categories", None) or ["biolink:NamedThing"]
+            for descendant in get_subcategories(category)
+        ]
+        node.pop("is_set", None)
+    for edge in qgraph["edges"].values():
+        edge["predicates"] = [
+            descendant
+            for predicate in node.get("predicates", None) or ["biolink:related_to"]
+            for descendant in get_subpredicates(predicate)
+        ]

--- a/icees_api/features/qgraph_utils.py
+++ b/icees_api/features/qgraph_utils.py
@@ -8,7 +8,10 @@ BMT = Toolkit()
 
 def get_subcategories(category):
     """Get sub-categories, according to the Biolink model."""
-    return BMT.get_descendants(category, formatted=True, reflexive=True)
+    return [
+        descendant.replace("_", "")
+        for descendant in BMT.get_descendants(category, formatted=True, reflexive=True)
+    ]
 
 
 def camelcase_to_snakecase(string):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+bmt==0.6.0
+linkml-model==1.0.0
 sqlalchemy
 psycopg2-binary
 scipy

--- a/test/api/test_knowledge_graph.py
+++ b/test/api/test_knowledge_graph.py
@@ -174,6 +174,57 @@ def test_knowledge_graph_one_hop(query_options):
     11,2010,0-2,1,4
     12,2010,0-2,>1,4
 """)
+def test_knowledge_graph_semantic_ops(query_options):
+    """Test one-hop."""
+    query = {
+        "query_options": query_options,
+        "message": {
+            "query_graph": {
+                "nodes": {
+                    "n00": {
+                        "ids": ["PUBCHEM:2083"]
+                    },
+                    "n01": {}
+                },
+                "edges": {
+                    "e00": {
+                        "predicates": ["biolink:related_to"],
+                        "subject": "n00",
+                        "object": "n01"
+                    }
+                }
+            }
+        }
+    }
+    resp_json = validate_response(testclient.post(
+        "/knowledge_graph_one_hop",
+        json=query,
+        params={"reasoner": False},
+    ))
+    assert "return value" in resp_json
+    message = resp_json["return value"]["message"]
+    assert len(message["results"]) == 3
+    assert len(message["knowledge_graph"]["nodes"]) == 3
+    assert len(message["knowledge_graph"]["edges"]) == 3
+
+
+@pytest.mark.parametrize("query_options", kg_options)
+@load_data(APP, """
+    PatientId,year,AgeStudyStart,Albuterol,AvgDailyPM2.5Exposure
+    varchar(255),int,varchar(255),varchar(255),int
+    1,2010,0-2,0,1
+    2,2010,0-2,1,1
+    3,2010,0-2,>1,1
+    4,2010,0-2,0,2
+    5,2010,0-2,1,2
+    6,2010,0-2,>1,2
+    7,2010,0-2,0,3
+    8,2010,0-2,1,3
+    9,2010,0-2,>1,3
+    10,2010,0-2,0,4
+    11,2010,0-2,1,4
+    12,2010,0-2,>1,4
+""")
 def test_knowledge_graph_wrong_predicate(query_options):
     """Test one-hop."""
     query = {

--- a/test/api/test_knowledge_graph.py
+++ b/test/api/test_knowledge_graph.py
@@ -174,6 +174,57 @@ def test_knowledge_graph_one_hop(query_options):
     11,2010,0-2,1,4
     12,2010,0-2,>1,4
 """)
+def test_knowledge_graph_wrong_predicate(query_options):
+    """Test one-hop."""
+    query = {
+        "query_options": query_options,
+        "message": {
+            "query_graph": {
+                "nodes": {
+                    "n00": {
+                        "ids": ["PUBCHEM:2083", "MESH:D052638"]
+                    },
+                    "n01": {
+                        "categories": ["biolink:PhenotypicFeature"]
+                    }
+                },
+                "edges": {
+                    "e00": {
+                        "predicates": ["biolink:affects"],
+                        "subject": "n00",
+                        "object": "n01"
+                    }
+                }
+            }
+        }
+    }
+    resp_json = validate_response(testclient.post(
+        "/knowledge_graph_one_hop",
+        json=query,
+        params={"reasoner": False},
+    ))
+    assert "return value" in resp_json
+    message = resp_json["return value"]["message"]
+    assert not message["results"]
+
+
+@pytest.mark.parametrize("query_options", kg_options)
+@load_data(APP, """
+    PatientId,year,AgeStudyStart,Albuterol,AvgDailyPM2.5Exposure
+    varchar(255),int,varchar(255),varchar(255),int
+    1,2010,0-2,0,1
+    2,2010,0-2,1,1
+    3,2010,0-2,>1,1
+    4,2010,0-2,0,2
+    5,2010,0-2,1,2
+    6,2010,0-2,>1,2
+    7,2010,0-2,0,3
+    8,2010,0-2,1,3
+    9,2010,0-2,>1,3
+    10,2010,0-2,0,4
+    11,2010,0-2,1,4
+    12,2010,0-2,>1,4
+""")
 def test_knowledge_graph_source_returned(query_options):
     """Test one-hop."""
     query = {

--- a/test/api/test_knowledge_graph.py
+++ b/test/api/test_knowledge_graph.py
@@ -71,7 +71,7 @@ def test_knowledge_graph_overlay(query_options):
             "knowledge_graph": {
                 "nodes": {
                     "PUBCHEM:2083": {
-                        "categories": ["biolink:Drug"]
+                        "categories": ["biolink:ChemicalSubstance"]
                     },
                     "MESH:D052638": {
                         "categories": ["biolink:ChemicalSubstance"]
@@ -310,7 +310,7 @@ def test_knowledge_graph_source_returned(query_options):
     assert len(message["results"]) == 2
     assert len(message["knowledge_graph"]["nodes"]) == 3
     assert len(message["knowledge_graph"]["edges"]) == 2
-    assert message["knowledge_graph"]["nodes"]["PUBCHEM:2083"]["categories"] == ["biolink:Drug"]
+    assert message["knowledge_graph"]["nodes"]["PUBCHEM:2083"]["categories"] == ["biolink:ChemicalSubstance"]
 
 
 @pytest.mark.parametrize("query_options", kg_options)

--- a/test/config/mappings.yml
+++ b/test/config/mappings.yml
@@ -10,7 +10,7 @@ AsthmaDx:
   - MONDO:0004979
 Albuterol:
   categories:
-  - biolink:Drug
+  - biolink:ChemicalSubstance
   identifiers:
   - PUBCHEM:2083
 AvgDailyPM2.5Exposure:


### PR DESCRIPTION
ICEES will now traverse down the Biolink hierarchy for node categories and edge predicates. For example, it will respond to queries about `biolink:DiseaseOrPhenotypicFeature` and `biolink:related_to` with `biolink:Disease`, `biolink:PhenotypicFeature`, and `biolink:correlated_with`.