### PR TITLE
add restart always for redis service container

### DIFF
--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -3,6 +3,7 @@ services:
   redis:
     image: redis:latest
     container_name: ${ICEES_API_INSTANCE_NAME}-cache
+    restart: always
   server:
     build: 
       context: .


### PR DESCRIPTION
@kennethmorton This PR will fix the issue of redis cache container not restarting after it went down for some reason, e.g., server restart.