### PR TITLE
Change docker user to non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
+# create a new user and use it.
+RUN useradd -M -u 1001 nonrootuser
+USER nonrootuser
+
 # set up API things
 COPY ./icees_api icees_api
 COPY ./main.sh main.sh


### PR DESCRIPTION
This just changes the user inside the docker container to one that isn't root. Main reason: The Sterling Kubernetes Cluster has strict policies and doesn't allow root users.

__IMPORTANT:__ This might affect the file system access the API needs. I remember we were seeing errors when the API couldn't read config files it needed, and a non-root user might not be able to read those files. We should test this out before deploying.