### PR TITLE
make containers run as iceesuser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,31 @@
 FROM python:3.8
 
-WORKDIR /
+ARG UID
+ARG GID
 
+# set environment variables
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /
 # install requirements
 COPY ./requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
 # create a new user and use it.
-RUN useradd -M -u 1001 nonrootuser
-USER nonrootuser
+RUN mkdir -p /home/iceesuser
+RUN groupadd --system -g $GID iceesuser && useradd --system -g iceesuser --shell /bin/bash -u $UID --home /home/iceesuser iceesuser
 
+WORKDIR /home/iceesuser
 # set up API things
 COPY ./icees_api icees_api
 COPY ./main.sh main.sh
 COPY ./examples examples
+
+RUN chown -R iceesuser:iceesuser /home/iceesuser
+
+USER iceesuser
+WORKDIR /home/iceesuser
 
 # run API
 CMD ["./main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ COPY ./examples examples
 RUN chown -R iceesuser:iceesuser /home/iceesuser
 
 USER iceesuser
-WORKDIR /home/iceesuser
 
 # run API
 CMD ["./main.sh"]

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -7,7 +7,11 @@ services:
   server:
     build: 
       context: .
-    image: icees-api-server:0.5.0
+      dockerfile: Dockerfile
+      args:
+        UID: $UID
+        GID: $GID
+    image: icees-api-server:0.5.1
     container_name: ${ICEES_API_INSTANCE_NAME}-server
     env_file:
       - .env


### PR DESCRIPTION
@maximusunc I found with your PR merged, even though containers run as nonrootuser, all files are still owned by root inside the container and the work directory is ```/``` which is also not good as the work directory of the nonrootuser. This PR will fix all these issues and create a home directory for the new non-root user named as iceesuser. I tested this PR on ebcr0 using DILI dev instance and everything works with ICEES code copied to ```/home/iceesuser``` work directory with the correct permission. The log directory permission is also correctly owned by iceesuser. Please take a look at the PR. Once it is approved, I can merge it to master and use that as the base image to be used for Sterling deployment of ICEES API service.