### PR TITLE
fixed a type in rediness probe for DILI dev k8s deployment

### DIFF
--- a/k8s/DILI/dev/server-deployment.yaml
+++ b/k8s/DILI/dev/server-deployment.yaml
@@ -105,7 +105,7 @@ spec:
           readinessProbe:
             periodSeconds: 5
             httpGet:
-              path: /api    
+              path: /apidocs    
               port: 8080
           volumeMounts:
             - name: iceesdata          


### PR DESCRIPTION
@maximusunc Can you take a quick look of this typo fix, i.e., change ```/api``` to ```/apidocs``` in readiness probe specification. Thanks