### PR TITLE
fixed redis connection issue in Sterling

### DIFF
--- a/k8s/DILI/dev/server-deployment.yaml
+++ b/k8s/DILI/dev/server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
               value: "development"
             - name: OPENAPI_SERVER_LOCATION
               value: "RENCI"
+            - name: REDIS_HOST
+              value: "redis-dili-dev"
           livenessProbe:
             periodSeconds: 5
             httpGet:

--- a/k8s/DILI/prod/server-deployment.yaml
+++ b/k8s/DILI/prod/server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
              value: "production"
            - name: OPENAPI_SERVER_LOCATION
              value: "RENCI"
+           - name: REDIS_HOST
+             value: "redis-dili"  
           livenessProbe:
             periodSeconds: 5
             httpGet:

--- a/k8s/PCD/dev/server-deployment.yaml
+++ b/k8s/PCD/dev/server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
              value: "development"
            - name: OPENAPI_SERVER_LOCATION
              value: "RENCI"
+           - name: REDIS_HOST
+             value: "redis-pcd-dev"  
           livenessProbe:
             periodSeconds: 5
             httpGet:

--- a/k8s/PCD/prod/server-deployment.yaml
+++ b/k8s/PCD/prod/server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
              value: "production"
            - name: OPENAPI_SERVER_LOCATION
              value: "RENCI"
+           - name: REDIS_HOST
+             value: "redis-pcd"  
           livenessProbe:
             periodSeconds: 5
             httpGet:

--- a/k8s/asthma/dev/server-deployment.yaml
+++ b/k8s/asthma/dev/server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
              value: "development"
            - name: OPENAPI_SERVER_LOCATION
              value: "RENCI"
+           - name: REDIS_HOST
+             value: "redis-asthma-dev"  
           livenessProbe:
             periodSeconds: 5
             httpGet:

--- a/k8s/asthma/prod/server-deployment.yaml
+++ b/k8s/asthma/prod/server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
              value: "production"
            - name: OPENAPI_SERVER_LOCATION
              value: "RENCI"
+           - name: REDIS_HOST
+             value: "redis-asthma"   
           livenessProbe:
             periodSeconds: 5
             httpGet:


### PR DESCRIPTION
@maximusunc This PR fixes the redis connection issue in k8s Sterling deployment. Specifically, REDIS_HOST environment variable has to be set since otherwise, localhost would be used which did not work on Sterling. 